### PR TITLE
Hide app switcher in MS Teams fixed cookies in MsTeams

### DIFF
--- a/app/components/NavigationMenu.vue
+++ b/app/components/NavigationMenu.vue
@@ -3,7 +3,7 @@ import type { DropdownMenuItem } from "@nuxt/ui";
 
 // Add translation hook
 const { t } = useI18n();
-const { data, signOut, isAuthEnabled } = useAppAuth();
+const { data, signOut, isAuthEnabled, inMsTeams } = useAppAuth();
 const { ribbonTab, setRibbonTab } = useRibbonTab();
 
 const userImage = computed(() => {
@@ -29,7 +29,7 @@ const apps = useAppList("TextMate");
 
 <template>
     <div>
-        <NavigationBar :other-apps="apps">
+        <NavigationBar :other-apps="apps" :show-app-switcher="!inMsTeams">
             <template #center>
                 <div class="hidden md:flex items-end gap-1">
                     <UButton

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "nuxt-app",
       "dependencies": {
-        "@dcc-bs/common-ui.bs.js": "2.1.3",
+        "@dcc-bs/common-ui.bs.js": "2.1.4",
         "@dcc-bs/communication.bs.js": "^0.1.3",
         "@dcc-bs/dependency-injection.bs.js": "^0.0.16",
         "@dcc-bs/event-system.bs.js": "^1.4.3",
@@ -163,7 +163,7 @@
 
     "@colordx/core": ["@colordx/core@5.5.0", "", {}, "sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ=="],
 
-    "@dcc-bs/common-ui.bs.js": ["@dcc-bs/common-ui.bs.js@2.1.3", "", { "dependencies": { "@nuxt/kit": "4.4.8", "@nuxtjs/i18n": "10.4.0", "defu": "^6.1.4", "driver.js": "^1.6.0", "gray-matter": "^4.0.3", "markdown-it": "14.2.0", "semver": "7.8.4", "tailwind-merge": "3.6.0", "typescript": "5.9.3" }, "peerDependencies": { "@nuxt/icon": "^2.2.1", "@nuxt/ui": "^4.5.1", "motion-v": "^2.0.1", "nuxt": "^4.4.2", "zod": "^4.3.6" } }, "sha512-Z4EzB2LNRrDhQ2TcsiXFDHXpENaRc66lWEH020B/P3ESn8sJqkAnP+3VFNQUgbm/Py7GHP7r96rSM8A3tBafZA=="],
+    "@dcc-bs/common-ui.bs.js": ["@dcc-bs/common-ui.bs.js@2.1.4", "", { "dependencies": { "@nuxt/kit": "4.4.8", "@nuxtjs/i18n": "10.4.0", "defu": "^6.1.4", "driver.js": "^1.6.0", "gray-matter": "^4.0.3", "markdown-it": "14.2.0", "semver": "7.8.4", "tailwind-merge": "3.6.0", "typescript": "5.9.3" }, "peerDependencies": { "@nuxt/icon": "^2.2.1", "@nuxt/ui": "^4.5.1", "motion-v": "^2.0.1", "nuxt": "^4.4.2", "zod": "^4.3.6" } }, "sha512-7t2LBdxEKraG5y3o3czPMm2T6yBRpIUPjK+r0v1dospjJVuL4m6meO/JtIid7gdJ5wbTBpQEuLx+rIfJH31J+Q=="],
 
     "@dcc-bs/communication.bs.js": ["@dcc-bs/communication.bs.js@0.1.3", "", { "dependencies": { "vite": "^7.1.6", "vue": "^3.5.25", "zod": "^4.1.9" }, "peerDependencies": { "typescript": "^5" } }, "sha512-6lMlGaGy/zJtl544Y0loB5kgaf9MKC5t4OhKb+wPC1Cg5Y08KmYIyp8kfr/TresuhNtSfPIUEs3phWLJuxGSaQ=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "e2e:codegen": "playwright codegen http://localhost:3000"
     },
     "dependencies": {
-        "@dcc-bs/common-ui.bs.js": "2.1.3",
+        "@dcc-bs/common-ui.bs.js": "2.1.4",
         "@dcc-bs/communication.bs.js": "^0.1.3",
         "@dcc-bs/dependency-injection.bs.js": "^0.0.16",
         "@dcc-bs/event-system.bs.js": "^1.4.3",


### PR DESCRIPTION
Upgrade @dcc-bs/common-ui.bs.js to 2.1.4 to
support the new show-app-switcher prop.